### PR TITLE
Fix temporary path creation logic and extension name resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,14 +184,15 @@ function createTempPath(tmpdir, options, callback) {
   tmpdir = getTempPath(tmpdir);
 
   const extension = (options.ext)
-    ? (options.ext.startsWith('.')
-        ? options.ext
-        // feat: Add support for creation temporary file with no extension
-        //// : (options.ext === '' ? defaultExt : '.' + options.ext);
-        : `.${options.ext}`
-      )
+    ? options.ext.startsWith('.')
+      ? options.ext
+      : `.${options.ext}`
     // Use default extension, if the extension name is not specified
-    : '.tmp';
+    // * feat: Add support for temporary file creation with no extension
+    : ((typeof options.ext === 'string' && options.ext.length === 0)
+      ? options.ext
+      : '.tmp'
+    );
 
   // Create the parent directory of generated temporary path
   fs.promises.mkdir(path.dirname(tmpdir), { recursive: true })
@@ -290,11 +291,13 @@ function createTempPathSync(tmpdir, options) {
   const extension = (options.ext)
     ? options.ext.startsWith('.')
       ? options.ext
-      // feat: Add support for creation temporary file with no extension
-      //// : (options.ext === '' ? defaultExt : '.' + options.ext);
       : `.${options.ext}`
     // Use default extension, if the extension name is not specified
-    : '.tmp';
+    // * feat: Add support for temporary file creation with no extension
+    : ((typeof options.ext === 'string' && options.ext.length === 0)
+      ? options.ext
+      : '.tmp'
+    );
 
   try {
     // Create the parent directory of generated temporary path

--- a/index.js
+++ b/index.js
@@ -193,24 +193,23 @@ function createTempPath(tmpdir, options, callback) {
     // Use default extension, if the extension name is not specified
     : '.tmp';
 
-  fs.promises.mkdir(tmpdir, { recursive: true })
+  // Create the parent directory of generated temporary path
+  fs.promises.mkdir(path.dirname(tmpdir), { recursive: true })
     .then(function () {
       if (options.asFile) {
         const filename = tmpdir + extension;
+        // Create an empty file in the temporary directory
         fs.promises.writeFile(filename, '')
-          .then(function () {
-            callback(null, filename);  // Return the created the temporary file path
-          })
-          .catch(function (writeErr) {
-            callback(writeErr);
-          });
+          .then(() => callback(null, filename))  // Return the created the temporary file path
+          .catch(err => callback(err));
       } else {
-        callback(null, tmpdir);  // Return the created temporary directory path
+        // Create an empty directory in the temporary directory
+        fs.promises.mkdir(tmpdir)
+          .then(() => callback(null, tmpdir))  // Return the created temporary directory path
+          .catch(err => callback(err));
       }
     })
-    .catch(function (err) {
-      callback(err);
-    });
+    .catch(err => callback(err));
 }
 
 /**
@@ -278,8 +277,8 @@ function createTempPathSync(tmpdir, options) {
   }
 
   if (typeof options !== 'object') {
-      throw new TypeError(
-          `The "options" argument must be an object. Received ${typeof options}`);
+    throw new TypeError(
+      `The "options" argument must be an object. Received ${typeof options}`);
   }
   if (options.ext && typeof options.ext !== 'string') {
     throw new TypeError(`Expected a string extension, got ${typeof options.ext}`);
@@ -298,15 +297,17 @@ function createTempPathSync(tmpdir, options) {
     : '.tmp';
 
   try {
-    // Create a temporary directory with synchronous operation
-    fs.mkdirSync(tmpdir, { recursive: true });
+    // Create the parent directory of generated temporary path
+    fs.mkdirSync(path.dirname(tmpdir), { recursive: true });
 
     if (options.asFile) {
       const filename = tmpdir + extension;
-      fs.writeFileSync(filename, '');
+      fs.writeFileSync(filename, '');  // Create an empty temporary file
       return filename;  // Return the created temporary file path
     }
 
+    // Create a temporary directory with synchronous operation
+    fs.mkdirSync(tmpdir);
     return tmpdir;  // Return the created temporary directory path
   } catch (err) {
     // Throw a new error with source error as causative error


### PR DESCRIPTION
## Overview

This pull request addresses issues in the `createTempPath` and `createTempPathSync` functions to ensure correct temporary path creation and proper handling of file extensions, including cases where no extension is specified.

## Changes Made

### Fixes

- **Fix the ternary expression on extension name resolver** (5d17024)
  - Resolved an issue where specifying an empty string (`''`) for `options.ext` was treated as a null value, causing the function to fallback to the default extension ('.tmp').
  - Now, the function correctly handles the creation of temporary files with no extension when an empty string is provided.

  > The creation of temporary file with no extension has been a part of this module features since #2, but I forgot to mention it on the PR description.

- **Fix the logic of temporary path creation** (74643db)
  - Ensured the parent directory of the temporary path exists before creating temporary files or directories.
  - Previously, the function attempted to create the temporary directory and file with the same name in a single process, which caused failures when creating temporary files with no extension.
  - Adjusted the logic to separate the creation of the directory and the file, preventing conflicts and ensuring successful creation of both.

## Summary

This pull request corrects the logic for creating temporary paths, particularly focusing on ensuring parent directories exist and handling empty string extensions correctly. These changes improve the reliability and flexibility of temporary file and directory creation.
