### PR TITLE
Add `maxLen` option to control temporary path name length

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,14 +77,17 @@ function __getTempDir() {
  * @throws {TypeError} Throws a `TypeError` if the provided `tmpdir` is not a string.
  * @since 0.1.0
  */
-function getTempPath(tmpdir) {
+function getTempPath(tmpdir, maxLen) {
   if (tmpdir && typeof tmpdir !== 'string') {
     throw new TypeError(`Expected type is string. Received ${typeof tmpdir}`);
+  }
+  if (maxLen <= 0) {
+    throw new RangeError('Maximum characters must be greater than zero');
   }
 
   return path.join(
     (isNullOrUndefined(tmpdir) || tmpdir.length === 0) ? __getTempDir() : tmpdir,
-    randomUUID().replace(/-/g, '')
+    randomUUID().replace(/-/g, '').substr(0, maxLen)
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ const { randomUUID } = require('node:crypto');
  * @property {boolean} [asFile=false] - Whether to create a temporary file instead directory.
  * @property {string}  [ext='.tmp'] - An extension name to use for tempoarary file creation.
  *                                    Ignored if the `asFile` is set to `false`.
+ * @property {number}  [maxLen=32] - The maximum characters' length of the generated temporary
+ *                                   directory or file name.
  * @global
  * @since  0.3.0
  */
@@ -67,14 +69,24 @@ function __getTempDir() {
  * 
  * This function utilizes a random UUID for the directory name, ensuring that each time
  * it is called, the path will be different from previous calls. The returned path can be
- * used for either a temporary file or directory, according to your preferences.
+ * used for either a temporary file or directory, according to user preferences.
+ *
+ * To limit the characters' length of generated temporary directory or file name,
+ * set the `maxLen` to the desired value and it must be a positive number.
+ * Thus, the function will trim the name to the desired maximum length.
  *
  * @public
  * @function
  * @param {string} [tmpdir] - The temporary directory path. If not provided or empty,
  *                            it defaults to the system's temporary directory.
+ * @param {number} [maxLen=32] - The maximum characters' length of the generated temporary path.
+ *                            Must be a positive number and greater than zero.
+ *
  * @returns {string} The generated temporary path.
+ *
  * @throws {TypeError} Throws a `TypeError` if the provided `tmpdir` is not a string.
+ * @throws {RangeError} If the given `maxLen` is less than or equal to zero.
+ *
  * @since 0.1.0
  */
 function getTempPath(tmpdir, maxLen) {
@@ -96,6 +108,10 @@ function getTempPath(tmpdir, maxLen) {
  * based on the provided or system temporary directory.
  *
  * This function utilizes the {@link module:temppath~getTempPath|getTempPath} function.
+ * To limit the characters' length of generated temporary directory or file name,
+ * set the {@link TempPathOptions.maxLen `options.maxLen`} to the desired value and
+ * it must be a positive number. Thus, the function will trim the name to the desired
+ * maximum length.
  *
  * @public
  * @async
@@ -110,8 +126,10 @@ function getTempPath(tmpdir, maxLen) {
  * @param {boolean} [options.asFile=false] - If `true`, create a temporary file. Otherwise, create a directory.
  * @param {string} [options.ext='.tmp'] - The extension for the temporary file. If `asFile` option is `false`,
  *                                        this option will be ignored. Default is '.tmp'.
+ * @param {number} [options.maxLen=32] - The maximum characters' length of the generated directory or file name.
+ *                                       Defaults to 32 characters.
  * @param {CreateTempPathCallback} callback - A callback function to handle the result path or error.
- *                                                            This is crucial and required, even when you wanted to omit all arguments.
+ *                                            This is crucial and required, even when you wanted to omit all arguments.
  *
  * @throws {TypeError} If the given arguments or the extension name specified with incorrect type.
  *
@@ -224,6 +242,10 @@ function createTempPath(tmpdir, options, callback) {
  * or system temporary directory and then returns a path that refers to the generated temporary directory or file.
  *
  * This function utilizes the {@link module:temppath~getTempPath|getTempPath} function.
+ * To limit the characters' length of generated temporary directory or file name,
+ * set the {@link TempPathOptions.maxLen `options.maxLen`} to the desired value and
+ * it must be a positive number. Thus, the function will trim the name to the desired
+ * maximum length.
  *
  * @public
  * @function
@@ -233,7 +255,9 @@ function createTempPath(tmpdir, options, callback) {
  * @param {Object} [options] - Options for creating the temporary path.
  * @param {boolean} [options.asFile=false] - If `true`, create a temporary file. Otherwise, create a directory.
  * @param {string} [options.ext='.tmp'] - The extension for the temporary file. If `asFile` option is `false`,
- *                                        this option will be ignored. Default is '.tmp'.
+ *                                        this option will be ignored. Default is `'.tmp'`.
+ * @param {number} [options.maxLen=32] - The maximum characters' length of the generated directory or file name.
+ *                                       Defaults to 32 characters.
  *
  * @returns {string} The path of the created temporary directory or file.
  *

--- a/index.js
+++ b/index.js
@@ -182,9 +182,12 @@ function createTempPath(tmpdir, options, callback) {
   if (options.ext && typeof options.ext !== 'string') {
     throw new TypeError(`Expected a string extension, got ${typeof options.ext}`);
   }
+  if (options.maxLen && typeof options.maxLen !== 'number') {
+    throw new TypeError(`Expected a number for maxLen, got ${typeof options.maxLen}`);
+  }
 
-  // Resolve the root temporary path
-  tmpdir = getTempPath(tmpdir);
+  // Resolve the temporary path
+  tmpdir = getTempPath(tmpdir, options.maxLen);
 
   const extension = (options.ext)
     ? options.ext.startsWith('.')
@@ -287,9 +290,12 @@ function createTempPathSync(tmpdir, options) {
   if (options.ext && typeof options.ext !== 'string') {
     throw new TypeError(`Expected a string extension, got ${typeof options.ext}`);
   }
+  if (options.maxLen && typeof options.maxLen !== 'number') {
+    throw new TypeError(`Expected a number for maxLen, got ${typeof options.maxLen}`);
+  }
 
-  // Resolve the root temporary path
-  tmpdir = getTempPath(tmpdir);
+  // Resolve the temporary path
+  tmpdir = getTempPath(tmpdir, options.maxLen);
 
   const extension = (options.ext)
     ? options.ext.startsWith('.')


### PR DESCRIPTION
## Overview

This pull request introduces a new feature that allows users to specify the maximum length of temporary path names through the `maxLen` option. This enhancement provides greater flexibility and control over the naming of temporary files and directories.

## Changes Made

### Features

- **Add `maxLen` param to `getTempPath` function** (2e24f73)
  - Introduced a new parameter `maxLen` to the `getTempPath` function.
  - The `maxLen` parameter accepts any positive number from 1 to 32, corresponding to the maximum UUID characters from `crypto.randomUUID()` (with strips `'-'` removed).
  - If the provided number is less than or equal to zero, a `RangeError` will be thrown.

- **Add and apply the `maxLen` option to `createTempPath` and `createTempPathSync`functions** (264d0a4)
  - Added a new `maxLen` option to the `TempPathOptions` object.
  - This option affects both `createTempPath` and `createTempPathSync` functions, allowing users to limit the length of generated temporary directory or file names.

### Documentation

- **Update and improve the API docs** (`0ed99ec`)
  - Added detailed descriptions for the new `maxLen` option.
  - Improved the existing documentation for better clarity and comprehensiveness.

## Example Usage

```js
const { getTempPath } = require('temppath');

// Set the max chars' length to 20
console.log(getTempPath(null, 20));
  // Linux: $TMPDIR/be0ba8cb230d43828e9a
  // Windows: %TMP%\be0ba8cb230d43828e9a
```

## Summary

This pull request adds the `maxLen` option to control the maximum length of temporary path names, enhancing the flexibility and usability of the `temppath` module. Additionally, the API documentation has been updated to reflect these changes and provide clearer guidance on the new feature.
