### PR TITLE
Fix temporary directory fallback in `__getTempDir` internal function

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,12 +45,15 @@ function isNullOrUndefined(o) {
 }
 
 /**
- * Gets the temporary directory path based on the environment.
+ * Retrieves the temporary directory path based on the current environment.
  *
- * This function checks common environment variables for temporary directories,
- * such as TMPDIR on Unix-like and MacOS systems, and TMP/TEMP on Windows.
- * If no environment variable is set, it defaults to a 'tmp' directory
- * within the current working directory.
+ * This function first checks common environment variables for temporary directories:
+ * - `TMPDIR` on UNIX-like and macOS systems
+ * - `TMP` or `TEMP` on Windows systems
+ * 
+ * If none of these environment variables are set or return null, it falls back to the 
+ * `os.tmpdir()` function. If this also returns null, it uses the current working directory 
+ * and creates a new directory called `tmp`.
  *
  * @private
  * @function

--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ function isNullOrUndefined(o) {
 function __getTempDir() {
   return process.env.TMPDIR                   // Unix-like & MacOS systems
     || (process.env.TMP || process.env.TEMP)  // Windows system
-    || path.resolve(process.cwd(), 'tmp');    // Default path
+    || require('node:os').tmpdir()            // Fallback
+    || path.resolve(process.cwd(), 'tmp');    // Otherwise, use current directory
 }
 
 


### PR DESCRIPTION
## Overview

This pull request addresses and improves the fallback logic in the `__getTempDir` function to ensure it correctly determines the temporary directory path across different environments. The changes enhance the reliability of temporary directory retrieval by adding an additional fallback method.

## Changes Made

### Fixes

- **Fix fallback logic in `__getTempDir` function** (19bfc63)
  - Updated the `__getTempDir` function to include the `os.tmpdir()` method from the Node.js core as a fallback option.
  - Ensured that the function checks the following in order:
    1. `TMPDIR` environment variable (Unix-like and macOS systems).
    2. `TMP` or `TEMP` environment variables (Windows systems).
    3. `os.tmpdir()` method as a fallback if the environment variables are not set.
    4. The current working directory, creating a `tmp` directory if all other methods fail.

## Summary

This pull request enhances the robustness of the `__getTempDir` function by including the `os.tmpdir()` method from Node.js core as a fallback option. This change ensures the function correctly identifies the temporary directory path across various environments, improving overall reliability and functionality.
